### PR TITLE
DMS-71: Oracle Multitenant Support

### DIFF
--- a/yb_migrate/src/migration/common.go
+++ b/yb_migrate/src/migration/common.go
@@ -282,7 +282,8 @@ func SelectVersionQuery(dbType string, dbConnStr string) string {
 		}
 		defer db.Close()
 
-		query := "SELECT VERSION FROM V$INSTANCE"
+		query := "SELECT BANNER FROM V$VERSION"
+		// query sample output: Oracle Database 19c Enterprise Edition Release 19.0.0.0.0 - Production
 		err = db.QueryRow(query).Scan(&version)
 		if err != nil {
 			utils.ErrExit("run query %q on source: %s", query, err)


### PR DESCRIPTION
This PR fixes the issue #44

Output looks like:
```
[root@ip-10-9-80-202 cdb_oracle_sakila]#yb_migrate export --source-db-type oracle --source-db-user sakila --source-db-password password --source-db-schema sakila --source-db-name pdb1 --export-dir . --source-db-host 10.150.2.149 --source-db-port 1521 --start-clean
export of schema for source type as 'oracle'
ORACLE Version: Oracle Database 19c Enterprise Edition Release 19.0.0.0.0 - Production
exporting       TYPE            done
exporting   SEQUENCE            done
exporting      TABLE            done
exporting    SYNONYM            done
.....

```