### PR TITLE
Run generateReport on exported schema.

### DIFF
--- a/yb_migrate/cmd/export.go
+++ b/yb_migrate/cmd/export.go
@@ -65,7 +65,6 @@ var exportCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		// log.Infof("parent export command called with source data type = %s", source.DBType)
-		checkSchemaDirs()
 		checkDataDirs()
 		exportSchema()
 		exportData()

--- a/yb_migrate/cmd/exportSchema.go
+++ b/yb_migrate/cmd/exportSchema.go
@@ -16,7 +16,10 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/yugabyte/yb-db-migration/yb_migrate/src/migration"
 	"github.com/yugabyte/yb-db-migration/yb_migrate/src/utils"
@@ -39,49 +42,53 @@ to quickly create a Cobra application.`,
 	},
 
 	Run: func(cmd *cobra.Command, args []string) {
-		checkSchemaDirs()
 		exportSchema()
 	},
 }
 
 func exportSchema() {
-	utils.PrintIfTrue(fmt.Sprintf("export of schema for source type as '%s'\n", source.DBType), !source.GenerateReportMode)
-
+	if schemaIsExported(exportDir) {
+		if startClean {
+			proceed := utils.AskPrompt(
+				"CAUTION: Using --start-clean will overwrite any manual changes done to the " +
+					"exported schema. Do you want to proceed")
+			if !proceed {
+				return
+			}
+			for _, dirName := range []string{"schema", "reports", "temp", "metainfo/schema"} {
+				utils.CleanDir(filepath.Join(exportDir, dirName))
+			}
+			clearSchemaIsExported(exportDir)
+		} else {
+			fmt.Fprintf(os.Stderr, "Schema is already exported. "+
+				"Use --start-clean flag to export schema again -- "+
+				"CAUTION: Using --start-clean will overwrite any manual changes done to the exported schema.\n")
+			return
+		}
+	}
+	utils.PrintAndLog("export of schema for source type as '%s'\n", source.DBType)
 	// Check connection with source database.
 	err := source.DB().Connect()
 	if err != nil {
 		utils.ErrExit("Failed to connect to the source db: %s", err)
 	}
-
 	source.DB().CheckRequiredToolsAreInstalled()
-
-	if !source.GenerateReportMode {
-		migration.PrintSourceDBVersion(&source)
-	}
-
+	migration.PrintSourceDBVersion(&source)
 	migration.CreateMigrationProjectIfNotExists(&source, exportDir)
 
 	switch source.DBType {
 	case ORACLE:
-		utils.PrintIfTrue("preparing Ora2Pg for schema export from Oracle\n", source.VerboseMode, !source.GenerateReportMode)
-
 		migration.Ora2PgExtractSchema(&source, exportDir)
 	case POSTGRESQL:
-		utils.PrintIfTrue("preparing pg_dump for schema export from PG\n", source.VerboseMode, !source.GenerateReportMode)
-
 		migration.PgDumpExtractSchema(&source, exportDir)
 	case MYSQL:
-		utils.PrintIfTrue("preparing Ora2Pg for schema export from MySQL\n", source.VerboseMode, !source.GenerateReportMode)
-
 		migration.Ora2PgExtractSchema(&source, exportDir)
 	default:
-		fmt.Printf("Invalid source database type for export\n")
+		utils.ErrExit("Invalid source database type for export\n")
 	}
 
-	if !source.GenerateReportMode { //check is to avoid report generation twice via generateReport command
-		fmt.Printf("\nexported schema files created under directory: %s\n", exportDir+"/schema")
-		generateReport()
-	}
+	fmt.Printf("\nExported schema files created under directory: %s\n", exportDir+"/schema")
+	setSchemaIsExported(exportDir)
 }
 
 func init() {
@@ -95,22 +102,28 @@ func init() {
 
 }
 
-func checkSchemaDirs() {
-	schemaDir := exportDir + "/schema"
-	tempDir := exportDir + "/temp"
-	reportDir := exportDir + "/reports"
-	metainfoSchemaDir := exportDir + "/metainfo/schema"
-	if startClean {
-		utils.CleanDir(schemaDir)
-		utils.CleanDir(tempDir)
-		utils.CleanDir(reportDir)
-		utils.CleanDir(metainfoSchemaDir)
-	} else {
-		if !utils.IsDirectoryEmpty(schemaDir) {
-			utils.ErrExit("schema directory is not empty, use --start-clean flag to clean the directories and start")
+func schemaIsExported(exportDir string) bool {
+	flagFilePath := exportDir + "/metainfo/flags/exportSchemaDone"
+	_, err := os.Stat(flagFilePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false
 		}
-		if !utils.IsDirectoryEmpty(metainfoSchemaDir) {
-			utils.ErrExit("metainfo/schema directory is not empty, use --start-clean flag to clean the directories and start")
-		}
+		utils.ErrExit("failed to check if schema import is already done: %s", err)
 	}
+	return true
+}
+
+func setSchemaIsExported(exportDir string) {
+	flagFilePath := exportDir + "/metainfo/flags/exportSchemaDone"
+	fh, err := os.Create(flagFilePath)
+	if err != nil {
+		utils.ErrExit("create %q: %s", flagFilePath, err)
+	}
+	fh.Close()
+}
+
+func clearSchemaIsExported(exportDir string) {
+	flagFilePath := exportDir + "/metainfo/flags/exportSchemaDone"
+	os.Remove(flagFilePath)
 }

--- a/yb_migrate/cmd/exportSchema.go
+++ b/yb_migrate/cmd/exportSchema.go
@@ -87,7 +87,7 @@ func exportSchema() {
 		utils.ErrExit("Invalid source database type for export\n")
 	}
 
-	fmt.Printf("\nExported schema files created under directory: %s\n", exportDir+"/schema")
+	utils.PrintAndLog("\nExported schema files created under directory: %s\n", exportDir+"/schema")
 	setSchemaIsExported(exportDir)
 }
 

--- a/yb_migrate/src/migration/common.go
+++ b/yb_migrate/src/migration/common.go
@@ -191,11 +191,7 @@ func GetDriverConnStr(source *srcdb.Source) string {
 func PrintSourceDBVersion(source *srcdb.Source) string {
 	dbConnStr := GetDriverConnStr(source)
 	version := SelectVersionQuery(source.DBType, dbConnStr)
-
-	if !source.GenerateReportMode {
-		fmt.Printf("%s Version: %s\n", strings.ToUpper(source.DBType), version)
-	}
-
+	fmt.Printf("%s Version: %s\n", strings.ToUpper(source.DBType), version)
 	return version
 }
 
@@ -332,9 +328,6 @@ func CreateMigrationProjectIfNotExists(source *srcdb.Source, exportDir string) {
 	// log.Debugf("Creating a project directory...")
 	//Assuming export directory as a project directory
 	projectDirPath := exportDir
-	if source.GenerateReportMode {
-		projectSubdirs = []string{"temp", "temp/schema", "reports"}
-	}
 
 	for _, subdir := range projectSubdirs {
 		err := exec.Command("mkdir", "-p", projectDirPath+"/"+subdir).Run()
@@ -342,11 +335,9 @@ func CreateMigrationProjectIfNotExists(source *srcdb.Source, exportDir string) {
 	}
 
 	// Put info to metainfo/schema about the source db
-	if !source.GenerateReportMode {
-		sourceInfoFile := projectDirPath + "/metainfo/schema/" + "source-db-" + source.DBType
-		cmdOutput, err := exec.Command("touch", sourceInfoFile).CombinedOutput()
-		utils.CheckError(err, "", string(cmdOutput), true)
-	}
+	sourceInfoFile := projectDirPath + "/metainfo/schema/" + "source-db-" + source.DBType
+	cmdOutput, err := exec.Command("touch", sourceInfoFile).CombinedOutput()
+	utils.CheckError(err, "", string(cmdOutput), true)
 
 	schemaObjectList := utils.GetSchemaObjectList(source.DBType)
 
@@ -357,12 +348,7 @@ func CreateMigrationProjectIfNotExists(source *srcdb.Source, exportDir string) {
 		}
 		databaseObjectDirName := strings.ToLower(schemaObjectType) + "s"
 
-		var err error
-		if source.GenerateReportMode {
-			err = exec.Command("mkdir", "-p", projectDirPath+"/temp/schema/"+databaseObjectDirName).Run()
-		} else {
-			err = exec.Command("mkdir", "-p", projectDirPath+"/schema/"+databaseObjectDirName).Run()
-		}
+		err := exec.Command("mkdir", "-p", projectDirPath+"/schema/"+databaseObjectDirName).Run()
 		utils.CheckError(err, "", "couldn't create sub-directories under "+projectDirPath+"/schema", true)
 	}
 

--- a/yb_migrate/src/migration/oracle.go
+++ b/yb_migrate/src/migration/oracle.go
@@ -35,14 +35,7 @@ import (
 )
 
 func Ora2PgExtractSchema(source *srcdb.Source, exportDir string) {
-	var schemaDirPath string
-	if source.GenerateReportMode {
-		schemaDirPath = exportDir + "/temp/schema"
-	} else {
-		schemaDirPath = exportDir + "/schema"
-	}
-
-	//[Internal]: Decide whether to keep ora2pg.conf file hidden or not
+	schemaDirPath := exportDir + "/schema"
 	configFilePath := exportDir + "/temp/.ora2pg.conf"
 	populateOra2pgConfigFile(configFilePath, source)
 
@@ -52,12 +45,9 @@ func Ora2PgExtractSchema(source *srcdb.Source, exportDir string) {
 		if exportObject == "INDEX" {
 			continue // INDEX are exported along with TABLE in ora2pg
 		}
-		// utils.PrintIfTrue(fmt.Sprintf("starting export of %ss...\n", strings.ToLower(exportObject)), !source.GenerateReportMode)
-		if source.GenerateReportMode {
-			fmt.Printf("scanning %10s %5s", exportObject, "")
-		} else {
-			fmt.Printf("exporting %10s %5s", exportObject, "")
-		}
+
+		fmt.Printf("exporting %10s %5s", exportObject, "")
+
 		go utils.Wait(fmt.Sprintf("%10s\n", "done"), fmt.Sprintf("%10s\n", "error!"))
 
 		exportObjectFileName := utils.GetObjectFileName(schemaDirPath, exportObject)

--- a/yb_migrate/src/migration/postgres.go
+++ b/yb_migrate/src/migration/postgres.go
@@ -35,13 +35,8 @@ import (
 )
 
 func PgDumpExtractSchema(source *srcdb.Source, exportDir string) {
-	if source.GenerateReportMode {
-		fmt.Printf("scanning the schema %10s", "")
-	} else {
-		fmt.Printf("exporting the schema %10s", "")
-	}
+	fmt.Printf("exporting the schema %10s", "")
 	go utils.Wait("done\n", "error\n")
-
 	SSLQueryString := generateSSLQueryStringIfNotExists(source)
 	prepareYsqldumpCommandString := ""
 
@@ -65,11 +60,7 @@ func PgDumpExtractSchema(source *srcdb.Source, exportDir string) {
 	//Parsing the single file to generate multiple database object files
 	parseSchemaFile(source, exportDir)
 
-	if source.GenerateReportMode {
-		log.Info("Scanning of schema completed.")
-	} else {
-		log.Info("Export of schema completed.")
-	}
+	log.Info("Export of schema completed.")
 	utils.WaitChannel <- 0
 	<-utils.WaitChannel
 }
@@ -78,18 +69,9 @@ func PgDumpExtractSchema(source *srcdb.Source, exportDir string) {
 func parseSchemaFile(source *srcdb.Source, exportDir string) {
 	log.Info("Begun parsing the schema file.")
 	schemaFilePath := exportDir + "/temp" + "/schema.sql"
-	var schemaDirPath string
-	if source.GenerateReportMode {
-		schemaDirPath = exportDir + "/temp/schema"
-	} else {
-		schemaDirPath = exportDir + "/schema"
-	}
-
-	//CHOOSE - bufio vs ioutil(Memory vs Performance)?
+	schemaDirPath := exportDir + "/schema"
 	schemaFileData, err := ioutil.ReadFile(schemaFilePath)
-
 	utils.CheckError(err, "", "File not read", true)
-
 	schemaFileLines := strings.Split(string(schemaFileData), "\n")
 	numLines := len(schemaFileLines)
 
@@ -97,7 +79,6 @@ func parseSchemaFile(source *srcdb.Source, exportDir string) {
 	if err != nil {
 		panic(err)
 	}
-
 	//For example: -- Name: address address_city_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 	sqlTypeInfoCommentPattern, err := regexp.Compile("--.*Type:.*")
 	if err != nil {

--- a/yb_migrate/src/srcdb/source.go
+++ b/yb_migrate/src/srcdb/source.go
@@ -15,27 +15,26 @@ import (
 )
 
 type Source struct {
-	DBType             string
-	Host               string
-	Port               int
-	User               string
-	Password           string
-	DBName             string
-	DBSid              string
-	OracleHome         string
-	TNSAlias           string
-	Schema             string
-	SSLMode            string
-	SSLCertPath        string
-	SSLKey             string
-	SSLRootCert        string
-	SSLCRL             string
-	SSLQueryString     string
-	Uri                string
-	NumConnections     int
-	GenerateReportMode bool
-	VerboseMode        bool
-	TableList          string
+	DBType         string
+	Host           string
+	Port           int
+	User           string
+	Password       string
+	DBName         string
+	DBSid          string
+	OracleHome     string
+	TNSAlias       string
+	Schema         string
+	SSLMode        string
+	SSLCertPath    string
+	SSLKey         string
+	SSLRootCert    string
+	SSLCRL         string
+	SSLQueryString string
+	Uri            string
+	NumConnections int
+	VerboseMode    bool
+	TableList      string
 
 	sourceDB SourceDB
 }

--- a/yb_migrate/src/utils/logging.go
+++ b/yb_migrate/src/utils/logging.go
@@ -18,6 +18,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -46,6 +47,9 @@ func ErrExit(formatString string, args ...interface{}) {
 }
 
 func PrintAndLog(formatString string, args ...interface{}) {
-	fmt.Printf(formatString+"\n", args...)
 	log.Infof(formatString, args...)
+	if !strings.HasSuffix(formatString, "\n") {
+		formatString = formatString + "\n"
+	}
+	fmt.Printf(formatString, args...)
 }

--- a/yb_migrate/src/utils/utils.go
+++ b/yb_migrate/src/utils/utils.go
@@ -85,7 +85,7 @@ func AskPrompt(args ...string) bool {
 		}
 
 	}
-	fmt.Printf("?[Y/N]:")
+	fmt.Printf("? [Y/N]: ")
 
 	_, err := fmt.Scan(&input)
 
@@ -139,12 +139,11 @@ func FileOrFolderExists(path string) bool {
 func CleanDir(dir string) {
 	if FileOrFolderExists(dir) {
 		files, _ := filepath.Glob(dir + "/*")
-		fmt.Printf("cleaning directory: %s ...\n", dir)
+		log.Infof("cleaning directory: %s", dir)
 		for _, file := range files {
 			err := os.RemoveAll(file)
 			if err != nil {
-				fmt.Printf("%s\n", err.Error())
-				os.Exit(1)
+				ErrExit("clean dir %q: %s", dir, err)
 			}
 		}
 	}


### PR DESCRIPTION
This will enable users to iteratively refine the exported schema and
verify it.

-- `generateReport` fails if executed before `export schema`.
-- `temp/schema` is gone!
-- `export schema` creates a flag file in the `metainfo/flags` directory.
-- `generateReport` always looks for schema in the `schema/` directory.
-- `export schema` doesn't overwrite already exported schema--unless `--start-clean` flag is provided and user confirms her intention.
