### PR TITLE
Support for case sensitive object names in Oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,10 +298,8 @@ yb_migrate import --export-dir /path/to/yb/export/dir --target-db-host localhost
 
 Some of the important features and enhancements to follow soon are:
 
-- [Support for ONLINE migration from Oracle/PostgreSQL/MySQL](https://github.com/yugabyte/yb-db-migration/issues/55)
-- [Support case sensitive table-names migration from PostgreSQL](https://github.com/yugabyte/yb-db-migration/issues/53)
+- [Support for ONLINE migration from Oracle/PostgreSQL/MySQL](https://github.com/yugabyte/yb-db-migration/issues/50)
 - [Support migration to YugabyteDB cluster created on Yugabyte Cloud](https://github.com/yugabyte/yb-db-migration/issues/52)
 - [Reduce disk space requirements during migration process](https://github.com/yugabyte/yb-db-migration/issues/45)
-- [Support Oracle multi-tenant migration](https://github.com/yugabyte/yb-db-migration/issues/44)
 
 You can look at all the open issues [here](https://github.com/yugabyte/yb-db-migration/issues)

--- a/yb_migrate/cmd/exportDataStatus.go
+++ b/yb_migrate/cmd/exportDataStatus.go
@@ -58,7 +58,7 @@ func initializeExportTableMetadata(tableList []string) {
 			// schema.tablename format is required, as user can have access to similar table in different schema
 			tablesProgressMetadata[tableList[i]].TableSchema = source.Schema
 			tablesProgressMetadata[tableList[i]].TableName = tableInfo[len(tableInfo)-1] //tableInfo[0]
-			tablesProgressMetadata[tableList[i]].FullTableName = tablesProgressMetadata[tableList[i]].TableSchema + "." + tablesProgressMetadata[tableList[i]].TableName
+			tablesProgressMetadata[tableList[i]].FullTableName = fmt.Sprintf(`%s."%s"`,tablesProgressMetadata[tableList[i]].TableSchema,tablesProgressMetadata[tableList[i]].TableName)
 		} else if source.DBType == MYSQL {
 			// schema and database are same in MySQL
 			tablesProgressMetadata[tableList[i]].TableSchema = source.DBName

--- a/yb_migrate/cmd/importData.go
+++ b/yb_migrate/cmd/importData.go
@@ -436,21 +436,9 @@ func truncateTables(tables []string) {
 func splitDataFiles(importTables []string, taskQueue chan *fwk.SplitFileImportTask) {
 	log.Infof("Started goroutine: splitDataFiles")
 	for _, t := range importTables {
-		var tableNameUsed string //regenerating the table_data.sql filename, from extracted tableName
-		parts := strings.Split(t, ".")
 		sourceDBType := ExtractMetaInfo(exportDir).SourceDBType
-		switch sourceDBType {
-		case "postgresql":
-			if len(parts) > 1 && parts[0] != "public" {
-				tableNameUsed = strings.ToLower(parts[0]) + "."
-			}
-			tableNameUsed += parts[len(parts)-1]
-		case "mysql":
-			tableNameUsed = parts[len(parts)-1]
-		case "oracle":
-			tableNameUsed = strings.ToUpper(parts[len(parts)-1])
-		}
-		origDataFile := exportDir + "/data/" + tableNameUsed + "_data.sql"
+
+		origDataFile := exportDir + "/data/" + t + "_data.sql"
 		extractCopyStmtForTable(t, sourceDBType, origDataFile)
 		log.Infof("Start splitting table %q: data-file: %q", t, origDataFile)
 

--- a/yb_migrate/src/migration/common.go
+++ b/yb_migrate/src/migration/common.go
@@ -97,6 +97,9 @@ func UpdateTableRowCount(source *utils.Source, exportDir string, tablesProgressM
 		}
 
 		queryFrom := tablesProgressMetadata[key].FullTableName
+		if source.DBType == "oracle" {
+			queryFrom = fmt.Sprintf(`%s."%s"`, tablesProgressMetadata[key].TableSchema, tablesProgressMetadata[key].TableName)
+		}
 		rowCount := SelectCountStarFromTable(queryFrom, source)
 
 		if source.VerboseMode {

--- a/yb_migrate/src/migration/common.go
+++ b/yb_migrate/src/migration/common.go
@@ -88,7 +88,6 @@ func UpdateTableRowCount(source *utils.Source, exportDir string, tablesProgressM
 	sortedKeys := utils.GetSortedKeys(&tablesProgressMetadata)
 	for _, key := range sortedKeys {
 		utils.PrintIfTrue(fmt.Sprintf("|%s|\n", strings.Repeat("-", 65)), source.VerboseMode)
-		// fullTableName := tablesProgressMetadata[key].FullTableName
 
 		utils.PrintIfTrue(fmt.Sprintf("| %30s ", key), source.VerboseMode)
 
@@ -97,9 +96,6 @@ func UpdateTableRowCount(source *utils.Source, exportDir string, tablesProgressM
 		}
 
 		queryFrom := tablesProgressMetadata[key].FullTableName
-		if source.DBType == "oracle" {
-			queryFrom = fmt.Sprintf(`%s."%s"`, tablesProgressMetadata[key].TableSchema, tablesProgressMetadata[key].TableName)
-		}
 		rowCount := SelectCountStarFromTable(queryFrom, source)
 
 		if source.VerboseMode {

--- a/yb_migrate/src/migration/oracle.go
+++ b/yb_migrate/src/migration/oracle.go
@@ -291,8 +291,10 @@ func OracleGetAllTableNames(source *utils.Source) []string {
 	defer db.Close()
 
 	var tableNames []string
-	query := fmt.Sprintf("SELECT table_name FROM all_tables WHERE owner = '%s' "+
-		"AND TEMPORARY = 'N' AND table_name NOT LIKE 'DR$%%' ORDER BY table_name ASC", source.Schema)
+	query := fmt.Sprintf(`SELECT table_name FROM all_tables WHERE owner = '%s' 
+		AND TEMPORARY = 'N' AND table_name NOT LIKE 'DR$%%' AND (owner, table_name) not in 
+		(select owner, mview_name from all_mviews union all select log_owner, log_table from all_mview_logs)
+		ORDER BY table_name ASC`, source.Schema)
 	rows, err := db.Query(query)
 	if err != nil {
 		utils.ErrExit("error in querying source database for table names: %v", err)

--- a/yb_migrate/src/migration/oracle.go
+++ b/yb_migrate/src/migration/oracle.go
@@ -291,9 +291,17 @@ func OracleGetAllTableNames(source *utils.Source) []string {
 	defer db.Close()
 
 	var tableNames []string
-	query := fmt.Sprintf(`SELECT table_name FROM all_tables WHERE owner = '%s' 
-		AND TEMPORARY = 'N' AND table_name NOT LIKE 'DR$%%' AND (owner, table_name) not in 
-		(select owner, mview_name from all_mviews union all select log_owner, log_table from all_mview_logs)
+	/* below query will collect all tables under given schema except TEMPORARY tables,
+	Index related tables(start with DR$) and materialized view */
+	query := fmt.Sprintf(`SELECT table_name 
+		FROM all_tables 
+		WHERE owner = '%s' AND TEMPORARY = 'N' AND table_name NOT LIKE 'DR$%%' AND
+		(owner, table_name) not in ( 
+			SELECT owner, mview_name 
+			FROM all_mviews 
+			UNION ALL 
+			SELECT log_owner, log_table 
+			FROM all_mview_logs)
 		ORDER BY table_name ASC`, source.Schema)
 	rows, err := db.Query(query)
 	if err != nil {


### PR DESCRIPTION
From now onwards, case sensitive object names will be exported/imported without any error for Oracle, like MySQL and PostgreSQL