### PR TITLE
Changed default parallelism to 4 to speedup the data export

### DIFF
--- a/yb_migrate/cmd/export.go
+++ b/yb_migrate/cmd/export.go
@@ -82,7 +82,7 @@ func init() {
 	exportCmd.PersistentFlags().StringVar(&migrationMode, "migration-mode", "offline",
 		"mode can be offline | online(applicable only for data migration)")
 
-	exportCmd.PersistentFlags().IntVar(&source.NumConnections, "parallel-jobs", 1,
+	exportCmd.PersistentFlags().IntVar(&source.NumConnections, "parallel-jobs", 4,
 		"number of Parallel Jobs to extract data from source database[Note: applicable only for export data command]")
 }
 


### PR DESCRIPTION
For a small oracle experiment, this increased the speed of export data by 100%