### PR TITLE
Exit on pg_dump/ora2pg error.

### DIFF
--- a/yb_migrate/cmd/exportData.go
+++ b/yb_migrate/cmd/exportData.go
@@ -132,6 +132,8 @@ func exportDataOffline() bool {
 			log.Infoln("Cancel() being called, within exportDataOffline()")
 			cancel()                    //will cancel/stop both dump tool and progress bar
 			time.Sleep(time.Second * 5) //give sometime for the cancel to complete before this function returns
+			utils.ErrExit("yb_migrate encountered internal error. "+
+				"Check %s/yb_migrate.log for more details.", exportDir)
 		}
 	}()
 


### PR DESCRIPTION
Without the fix, yb_migrate hangs forever whenever pg_dump or ora2pg
failed to start for some reason.