### PR TITLE
Fix an issue where `export schema` hangs because of a regression.

### DIFF
--- a/yb_migrate/src/srcdb/pg_dump_extract_schema.go
+++ b/yb_migrate/src/srcdb/pg_dump_extract_schema.go
@@ -176,12 +176,12 @@ func extractSqlStatements(schemaFileLines []string, index *int) string {
 		if isSqlComment(schemaFileLines[(*index)]) {
 			break
 		} else if shouldSkipLine(schemaFileLines[(*index)]) {
+			(*index)++
 			continue
 		} else {
 			sqlStatement.WriteString(schemaFileLines[(*index)] + "\n")
+			(*index)++
 		}
-
-		(*index)++
 	}
 	return sqlStatement.String()
 }


### PR DESCRIPTION
A recent commit 9302b1981 introduced a regression because of which
`export schema` command went into an infinite loop. The change
missed incrementing loop index in one of the branches in the loop body.