### PR TITLE
Restore ora2pg parallelism to 1.

### DIFF
--- a/yb_migrate/cmd/export.go
+++ b/yb_migrate/cmd/export.go
@@ -82,8 +82,8 @@ func init() {
 	exportCmd.PersistentFlags().StringVar(&migrationMode, "migration-mode", "offline",
 		"mode can be offline | online(applicable only for data migration)")
 
-	exportCmd.PersistentFlags().IntVar(&source.NumConnections, "parallel-jobs", 4,
-		"number of Parallel Jobs to extract data from source database[Note: applicable only for export data command]")
+	exportCmd.PersistentFlags().IntVar(&source.NumConnections, "parallel-jobs", 1,
+		"number of Parallel Jobs to extract data from source database")
 }
 
 func registerCommonExportFlags(cmd *cobra.Command) {


### PR DESCRIPTION
ora2pg with -P set to value > 1 is failing to export all data.
Until ora2pg is fixed, we will disable parallelism in ora2pg.