### PR TITLE
Enable INDEXES_RENAMING option.

### DIFF
--- a/yb_migrate/src/srcdb/data/sample-ora2pg.conf
+++ b/yb_migrate/src/srcdb/data/sample-ora2pg.conf
@@ -522,7 +522,7 @@ PRESERVE_CASE	0
 # Could be very useful for database that have multiple time the same index name
 # or that use the same name than a table, which is not allowed by PostgreSQL
 # Disabled by default.
-INDEXES_RENAMING	0
+INDEXES_RENAMING	1
 
 # Operator classes text_pattern_ops, varchar_pattern_ops, and bpchar_pattern_ops
 # support B-tree indexes on the corresponding types. The difference from the


### PR DESCRIPTION
Without the option ora2pg was emitting duplicate index names.

Tested the migration using the sample sakila database located at:
https://downloads.mysql.com/docs/sakila-db.zip